### PR TITLE
Add Image-To-Image Pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "onnx-web-miniman",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://islamov.ai/stable-diffusion-webgpu",
+  "homepage": ".",
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
@@ -24,7 +24,8 @@
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "seedrandom": "3.0.5"
   },
   "scripts": {
     "start": "yarn setup && react-scripts start",

--- a/src/lib/StableDiffusionPipeline.ts
+++ b/src/lib/StableDiffusionPipeline.ts
@@ -23,25 +23,31 @@ export interface StableDiffusionInput {
   prompt: string
   negativePrompt?: string
   guidanceScale?: number
+  seed?: string
   width?: number
   height?: number
   numInferenceSteps: number
   sdV1?: boolean
   progressCallback?: ProgressCallback
   runVaeOnEachStep?: boolean
+  img2imgFlag: boolean
+  inputImage?: Float32Array
+  strength?: number
 }
 
 export class StableDiffusionPipeline {
   public unet: InferenceSession
   public vae: InferenceSession
+  public vae_encoder: InferenceSession
   public textEncoder: InferenceSession
   public tokenizer: CLIPTokenizer
   public scheduler: PNDMScheduler
   private sdVersion
 
-  constructor(unet: InferenceSession, vae: InferenceSession, textEncoder: InferenceSession, tokenizer: CLIPTokenizer, scheduler: PNDMScheduler, sdVersion: 1|2 = 2) {
+  constructor(unet: InferenceSession, vae: InferenceSession, vae_encoder: InferenceSession, textEncoder: InferenceSession, tokenizer: CLIPTokenizer, scheduler: PNDMScheduler, sdVersion: 1|2 = 2) {
     this.unet = unet
     this.vae = vae
+    this.vae_encoder = vae_encoder
     this.textEncoder = textEncoder
     this.tokenizer = tokenizer
     this.scheduler = scheduler
@@ -80,11 +86,16 @@ export class StableDiffusionPipeline {
 
     const opts = {
       progress_callback: hubProgressCallback,
+      // revision: '9f697c96d42e5c09437ff14b0a2b287366ce488d',
+      // local_files_only: true
     }
+    
     const sessionOption: InferenceSession.SessionOptions = { executionProviders: [executionProvider] }
+    
     const unet = await InferenceSession.create(await getModelFile(modelRepoOrPath, '/unet/model.onnx', true, opts), { executionProviders: ['wasm'] })
     const textEncoder = await InferenceSession.create(await getModelFile(modelRepoOrPath, '/text_encoder/model.onnx', true, opts), sessionOption)
     const vae = await InferenceSession.create(await getModelFile(modelRepoOrPath, '/vae_decoder/model.onnx', true, opts), sessionOption)
+    const vae_encoder = await InferenceSession.create(await getModelFile(modelRepoOrPath, '/vae_encoder/model.onnx', true, opts), sessionOption)
 
     const schedulerConfig = await getModelJSON(modelRepoOrPath, '/scheduler/scheduler_config.json', true, opts)
     const scheduler = await StableDiffusionPipeline.createScheduler(schedulerConfig)
@@ -93,7 +104,7 @@ export class StableDiffusionPipeline {
     progressCallback({
       step: 'Ready',
     })
-    return new StableDiffusionPipeline(unet, vae, textEncoder, tokenizer, scheduler, 2)
+    return new StableDiffusionPipeline(unet, vae, vae_encoder, textEncoder, tokenizer, scheduler, 2)
   }
 
   async encodePrompt (prompt: string): Promise<Tensor> {
@@ -125,20 +136,45 @@ export class StableDiffusionPipeline {
     const height = input.height || 512
     const batchSize = 1
     const guidanceScale = input.guidanceScale || 7.5
+    const seed = input.seed || ''
+
     this.scheduler.setTimesteps(input.numInferenceSteps || 5)
+
     await input.progressCallback!({
       step: 'Encoding prompt...',
     })
 
     const promptEmbeds = await this.getPromptEmbeds(input.prompt, input.negativePrompt)
 
-    const latentShape = [batchSize, 4, width / 8, height / 8]
-    let latents = randomNormalTensor(latentShape, undefined, undefined, 'float32')
+    const latentShape = [batchSize, 4, width / 8, height / 8];
+    let latents = randomNormalTensor(latentShape, undefined, undefined, 'float32', seed); // Normal latents used in Text-to-Image
+    let timesteps = this.scheduler.timesteps.data;
+
+    if(input.img2imgFlag) {
+      const inputImage = input.inputImage || new Float32Array()
+      const strength = input.strength || 0.8
+
+      await input.progressCallback!({
+        step: 'Encoding input image...',
+      })
+
+      const image_latent = await this.encodeImage(inputImage); // Encode image to latent space
+      
+      // Taken from https://towardsdatascience.com/stable-diffusion-using-hugging-face-variations-of-stable-diffusion-56fd2ab7a265#2d1d
+      const init_timestep = Math.round(input.numInferenceSteps * strength);
+      const timestep = timesteps.toReversed()[init_timestep];
+
+      latents = this.scheduler.add_noise(image_latent, latents, timestep);
+      // Computing the timestep to start the diffusion loop
+      const t_start = Math.max(input.numInferenceSteps - init_timestep, 0);
+      timesteps = timesteps.slice(t_start);
+    }
 
     const doClassifierFreeGuidance = guidanceScale > 1
     let humanStep = 1
     let cachedImages: Tensor[]|null = null
-    for (const step of this.scheduler.timesteps.data) {
+
+    for (const step of timesteps) {
       // for some reason v1.4 takes int64 as timestep input. ideally we should get input dtype from the model
       // but currently onnxruntime-node does not give out types, only input names
       const timestep = input.sdV1
@@ -191,6 +227,7 @@ export class StableDiffusionPipeline {
       // sleep to update UI
       await this.sleep(500)
     }
+    
 
     if (input.runVaeOnEachStep) {
       return cachedImages!
@@ -215,5 +252,16 @@ export class StableDiffusionPipeline {
       // .clipByValue(0, 255)
       // .transpose(0, 2, 3, 1)
     return [images]
+  }
+
+  // Taken from https://colab.research.google.com/github/fastai/diffusion-nbs/blob/master/Stable%20Diffusion%20Deep%20Dive.ipynb#scrollTo=42d594a2-cc70-4daf-81eb-005e906118d3&line=4&uniqifier=1
+  async encodeImage(input_image: Float32Array) {
+    const encoded = await sessionRun(
+      this.vae_encoder,
+      { sample: new Tensor('float32', input_image, [1, 3, 512, 512]) }
+    );
+
+    const encoded_image = encoded.latent_sample;
+    return encoded_image.mul(0.18215);
   }
 }

--- a/src/lib/Tensor.ts
+++ b/src/lib/Tensor.ts
@@ -1,5 +1,6 @@
 import { Tensor as ONNXTensor } from 'onnxruntime-common'
 import { Tensor } from '@xenova/transformers'
+import seedrandom from 'seedrandom';
 
 Tensor.prototype.reverse = function () {
   return new Tensor(this.type, this.data.reverse(), this.dims.slice());
@@ -211,18 +212,20 @@ export function linspace(start: number, end: number, num: number, type = 'float3
   return new Tensor(type, arr, [num]);
 }
 
-function randomNormal() {
+function randomNormal(rng: seedrandom.prng) {
   let u = 0, v = 0;
-  while(u === 0) u = Math.random();
-  while(v === 0) v = Math.random();
+
+  while(u === 0) u = rng();
+  while(v === 0) v = rng();
   let num = Math.sqrt( -2.0 * Math.log( u ) ) * Math.cos( 2.0 * Math.PI * v );
   return num;
 }
 
-export function randomNormalTensor(shape: number[], mean = 0, std = 1, type = 'float32') {
+export function randomNormalTensor(shape: number[], mean = 0, std = 1, type = 'float32', seed: string) {
   let data = [];
+  let rng = seed != '' ? seedrandom(seed) : seedrandom();
   for (let i = 0; i < shape.reduce((a, b) => a * b); i++) {
-    data.push(randomNormal() * std + mean);
+    data.push(randomNormal(rng) * std + mean);
   }
   return new Tensor(type, data, shape);
 }

--- a/src/lib/schedulers/PNDMScheduler.ts
+++ b/src/lib/schedulers/PNDMScheduler.ts
@@ -237,6 +237,15 @@ export class PNDMScheduler {
     return prevSample;
   }
 
+  // Taken from https://github.com/huggingface/diffusers/blob/d1e20be664dd8774e49d1a9d54fd71ec7cd5863c/src/diffusers/schedulers/scheduling_pndm.py#L453
+  add_noise(original_samples: Tensor, noise: Tensor, timestep: number) {
+    let sqrt_alpha_prod = this.alphasCumprod.data[timestep] ** 0.5;
+    let sqrt_one_minus_alpha_prod = (1 - this.alphasCumprod.data[timestep]) ** 0.5;
+
+    const noisy_samples = original_samples.mul(sqrt_alpha_prod).add(noise.mul(sqrt_one_minus_alpha_prod));
+    return noisy_samples
+  }
+
 }
 
 function betasForAlphaBar(numDiffusionTimesteps: number, maxBeta = 0.999) {


### PR DESCRIPTION
# Description

The changes include adding the Image-To-Image pipeline, along with the input fields for the Text-To-Image and Image-To-Image pipelines such as the Seed, Guidance Scale, Input Image and Strength. The Image-To-Image pipeline is basically the same as the Text-To-Image pipeline except that instead of having a random latent as input, a noisy input image is used as the input latent.

# Specific Changes

- [X] Add input elements to `App.tsx` file.
- [X] Add a function to get the RGB data from an image to `App.tsx`.
- [X] Add a function to upload an image, resize it to (512,512) and call the function to get the RGB data. Added to `App.tsx`.
- [X] Add a function called `encodeImage(input_image)` that uses the VAE Encoder to encode the input image from image space to latent space. The function was added to `StableDiffusionPipeline.ts`. The code was taken from the `pil_to_latent(input_im)` function shown [here](https://colab.research.google.com/github/fastai/diffusion-nbs/blob/master/Stable%20Diffusion%20Deep%20Dive.ipynb#scrollTo=42d594a2-cc70-4daf-81eb-005e906118d3&uniqifier=1).
- [X] Add a function to add noise to the input image called `add_noise()`.  Added to the `PNDMScheduler.ts` file. The code was taken from [here](https://github.com/huggingface/diffusers/blob/d1e20be664dd8774e49d1a9d54fd71ec7cd5863c/src/diffusers/schedulers/scheduling_pndm.py#L453).
- [X] Add the [seedrandom](https://github.com/davidbau/seedrandom) package to the `package.json` file in order to use a seedable Random Number Generator (RNG).
- [X] Modify the `randomNormal()` and `randomNormalTensor()` functions in the `Tensor.ts` file to accept the input seed and the RNG.
- [X] Call the `encodeImage()` and `add_noise()` functions and add a modification to the img2img timesteps depending on the strength and inference steps. Added to the `StableDiffusionPipeline.ts` file. Code taken from [here](https://towardsdatascience.com/stable-diffusion-using-hugging-face-variations-of-stable-diffusion-56fd2ab7a265#2d1d).

# Issues

To make the project work successfully, there were other slight changes done:

- [X] Downloaded the models locally following the steps mentioned [here](https://github.com/dakenf/stable-diffusion-webgpu-minimal/issues/2#issuecomment-1681274149).
- [X] Change the homepage in the `package.json` file to "."
- [X] Uncomment the `images` argument from the `runInference()` function in the `App.tsx` file. 